### PR TITLE
Feature: Erlaube im Linksplitter auch "Request" und "Cookies" als Variablen

### DIFF
--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -24,7 +24,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['linksplit_method'] = array
     'default'                 => 'GET',
     'exclude'                 => true,
     'inputType'               => 'select',
-    'options'                 => array('POST', 'GET', 'InsertTag'),
+    'options'                 => array('POST', 'GET', 'InsertTag', 'COOKIE', 'REQUEST'),
     'eval'                    => array('tl_class'=>'w50'),
     'sql'                     => "varchar(12) NOT NULL default ''"
 );

--- a/src/Resources/contao/modules/ModuleLinkSplitter.php
+++ b/src/Resources/contao/modules/ModuleLinkSplitter.php
@@ -68,6 +68,12 @@ class ModuleLinkSplitter extends \Module
                                 break;
             case 'InsertTag':   $value = $this->replaceInsertTags( $this->linksplit_var, false );
                                 break;
+            case 'COOKIE':      $value = \Input::cookie( $this->linksplit_var );
+                                break;
+            case 'REQUEST':     $value = \Input::post( $this->linksplit_var );
+                                if( $value =='' )
+                                    $value = \Input::get( $this->linksplit_var );
+                                break;
             default:            $value = '';
         }
         if( $value != '' ) {


### PR DESCRIPTION
Hallo do-while,

in einem Projekt habe ich den Linksplitter im Einsatz. Bedingt durch die Vorgaben müssen sowohl GET-Requests wie auch POST-Requests verarbeitet werden - mit identischen Werten. Für die CMS-Bediener wäre es vorteilhaft die Werte nur über eine Modul-Instanz zu verwalten, daher hier mein Pull-Request

Die Steuerung per Cookie wäre eine kleine "Dreingabe"
